### PR TITLE
fix cursor hover and convert percentages

### DIFF
--- a/src/CSS/MoviePoster.css
+++ b/src/CSS/MoviePoster.css
@@ -2,8 +2,8 @@
 	display: flex;
 	flex-direction: column;
 	justify-content: center;
-		/* border: 2px solid white; */
 }
+
 .movie-poster-container:hover {
 	transform: scale(1.1);
   cursor: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='40' height='48' viewport='0 0 100 100' style='fill:black;font-size:24px;'><text y='50%'>🔪</text></svg>")
@@ -15,6 +15,8 @@
   width: 100%;
   height: 40vh;
   border-radius: 10px;
+	cursor: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='40' height='48' viewport='0 0 100 100' style='fill:black;font-size:24px;'><text y='50%'>🔪</text></svg>")
+	16 0, auto;
 }
 
 .movie-rating-main {

--- a/src/CSS/MoviePreview.css
+++ b/src/CSS/MoviePreview.css
@@ -87,4 +87,6 @@
 .back-button:hover {
 	border-radius: 4px;
 	transform: scale(1.1);
+	cursor: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='40' height='48' viewport='0 0 100 100' style='fill:black;font-size:24px;'><text y='50%'>🔪</text></svg>")
+	16 0, auto;
 }

--- a/src/Components/MoviePoster.js
+++ b/src/Components/MoviePoster.js
@@ -8,7 +8,7 @@ const MoviePoster = ({id, title, posterImage, average}) => {
       <Link className="movie-poster" to={`/MoviePreview/${id}`} >
         <img className="movie-poster-image" src={posterImage} alt={title}></img>
       </Link>
-			<p className="movie-rating-main"><b>{average}%</b></p>
+			<p className="movie-rating-main"><b>{average * 10}%</b></p>
 			<h3 className="movie-title-main">{title}</h3>
     </article>
 	)

--- a/src/Components/MoviePreview.js
+++ b/src/Components/MoviePreview.js
@@ -39,7 +39,7 @@ class MoviePreview extends React.Component {
                 <h2 className="movie-title">{title}</h2>
                 <p className="movie-runtime">Runtime: {runtime} minutes</p>
                 <p className="movie-genres">{genres[0].name}</p>
-                <p className="movie-info">Average: {vote_average}</p><br></br>
+                <p className="movie-info">Average: {vote_average * 10}%</p><br></br>
                 <h4 className="movie-tagline">{tagline}</h4><br></br>
 								<h2 className="overview-header">Overview:</h2>
                 <p className="movie-overview">{overview}</p>


### PR DESCRIPTION
## Summary:
- Moved rating decimal by one place (i.e. 6.7% to 67%)
- Fixed cursor hover show the knife emoji would show on 'back to main' button and on homepage poster images

## Type of Changes:
- [ ] Bug fix
- [x] Refactor
- [ ] New feature


## How was this tested:
Google Chrome

## What are the relevant tickets:
Closes #20 